### PR TITLE
flake: update nixpkgs input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1691654369,
-        "narHash": "sha256-gSILTEx1jRaJjwZxRlnu3ZwMn1FVNk80qlwiCX8kmpo=",
+        "lastModified": 1713714899,
+        "narHash": "sha256-+z/XjO3QJs5rLE5UOf015gdVauVRQd2vZtsFkaXBq2Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ce5e4a6ef2e59d89a971bc434ca8ca222b9c7f5e",
+        "rev": "6143fc5eeb9c4f00163267708e26191d1e918932",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This PR updates the `nixpkgs` input to hopefully solve ISOs not properly booting due to regressions in the bootloader. I have tested this on `MacbookPro16,2` which does properly boot and does all the things a minimal live environment should. I have **not** tested if the bootloader installed by images built with this update will work, as I do not have a spare machine to test this on.

Note that the `nixos-hardware` input is not updated so as to keep the kernel at 6.4 due to issues reported.