### PR TITLE
Update CI flow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+groups:
+  version-updates:
+    applies-to: version-updates

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,13 +39,17 @@ jobs:
       env:
         GC_DONT_GC: 1
       run: |
-        for iso in $(nix flake show --json | nix run nixpkgs#jq -- -r keys[]); do
-          nix build .#$iso
-          split -d result/iso/*.iso -b 1G $iso.iso-part-
+        for output in $(nix flake show --json | nix run nixpkgs#jq -- -r 'keys[]'); do
+          nix build .#$output
+          if [ $(du -B1M result/iso/*.iso | cut -f1) -gt 2000 ]; then
+            split -d result/iso/*.iso -b 2000M nixos-$output.iso.part-
+          else
+            cp result/iso/*.iso nixos-$output.iso
+          fi
           rm result
         done
     - name: Release
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '.')
       with:
-        files: "*.iso-part-*"
+        files: "nixos-*.iso*"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,14 +23,14 @@ jobs:
         remove-codeql: 'true'
         remove-docker-images: 'true'
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: "Install Nix"
-      uses: cachix/install-nix-action@v18
+      uses: cachix/install-nix-action@v27
       with:
-        install_url: https://releases.nixos.org/nix/nix-2.13.3/install
+        install_url: https://releases.nixos.org/nix/nix-2.18.4/install
     - name: "Set Up Binary Cache"
       if: github.event_name != 'pull_request'
-      uses: cachix/cachix-action@v12
+      uses: cachix/cachix-action@v15
       with:
         name: t2linux
         authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/result
+*.iso*

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1719895800,
-        "narHash": "sha256-xNbjISJTFailxass4LmdWeV4jNhAlmJPwj46a/GxE6M=",
+        "lastModified": 1720372297,
+        "narHash": "sha256-bwy1rPQSQSCj/TNf1yswHW88nBQYvJQkeScGvOA8pd4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "6e253f12b1009053eff5344be5e835f604bb64cd",
+        "rev": "da0aa7b533d49e6319c603e07b46a5690082f65f",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1719848872,
-        "narHash": "sha256-H3+EC5cYuq+gQW8y0lSrrDZfH71LB4DAf+TDFyvwCNA=",
+        "lastModified": 1720031269,
+        "narHash": "sha256-rwz8NJZV+387rnWpTYcXaRNvzUSnnF9aHONoJIYmiUQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "00d80d13810dbfea8ab4ed1009b09100cca86ba8",
+        "rev": "9f4128e00b0ae8ec65918efeba59db998750ead6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This PR contains the following changes:

- update various action workflows
- update flake lock
- bumps maximum size for ISO files to 2000M (should be lower than GitHub's 2GiB limit)
- only do ISO splits when the size exceeds 2000M
- change ISO naming scheme
  - it should be clearer by default that ISO files are NixOS ISO files after downloading, especially when working with different distros.
- configure dependabot 
