### PR TITLE
ci: don't build dependabot prs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,9 +4,15 @@ on:
   push:
     paths-ignore:
       - "**.md"
+    branches:
+      - 'main'
+    tags:
+      - 'v*'
   pull_request:
     paths-ignore:
       - "**.md"
+    branches-ignore:
+      - 'dependabot/*'
 jobs:
   CI:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is a test PR to verify that CI stuff works at least semi-properly before merging.

## Changes
- don't build dependabot PRs
  - dependabot only manages GHA actions and shouldn't require a rebuild.
- This only build PRs, commit pushes to main and tags.